### PR TITLE
Remove deprecated website children

### DIFF
--- a/source/meta/frontmatter.ptx
+++ b/source/meta/frontmatter.ptx
@@ -82,12 +82,9 @@
 
   <colophon xml:id="colophon">
     <website>
-        <name>
-            Calculus for Team-Based Inquiry Learning
-            <fn><c>teambasedinquirylearning.github.io/calculus/</c></fn>
-        </name>
-        <address>https://teambasedinquirylearning.github.io/calculus/</address>
+      <url href="http://calculus.tbil.org">Calculus for Team-Based Inquiry Learning</url>
     </website>
+
     <xi:include href="./copyright.ptx" />
       <p>
 This work includes materials used under license from the following works:


### PR DESCRIPTION
Pretext has deprecated the use of `<name>` and `<addresss>` in a `<website>` element, in favor of a `<url>`.