### PR TITLE
Add xml:ids to images

### DIFF
--- a/source/01-LT/03.ptx
+++ b/source/01-LT/03.ptx
@@ -202,7 +202,7 @@
     </p>
                        <sidebyside>
                    <figure>
-                <image width="50%">
+                <image width="50%" xml:id="two-functions-limits">
                           <latex-image>
                   \begin{tikzpicture}[scale=1]
 \begin{axis}[ %human,
@@ -242,7 +242,7 @@
                     <caption> The graph of <m>f(x)</m>.</caption>
                 </figure>
   <figure>
-                <image width="50%">
+                <image width="50%" xml:id="graph-piecewise">
                           <latex-image>
 \begin{tikzpicture}[scale=1]
 

--- a/source/01-LT/04.ptx
+++ b/source/01-LT/04.ptx
@@ -237,7 +237,7 @@
           Consider the function <m>f</m> whose graph is pictured below.
         </p>
                     <figure>
-                <image width="50%">
+                <image width="50%" xml:id="graph-continuity-and-discontinuities">
                           <latex-image>
                   \begin{tikzpicture}[scale=1]
 \begin{axis}[  %human, 

--- a/source/01-LT/05.ptx
+++ b/source/01-LT/05.ptx
@@ -92,7 +92,7 @@
             </p>
             <sidebyside>
                 <figure>
-                    <image>
+                    <image xml:id="graph-horizontal-asymptotes-1">
                     <latex-image>
 
                         \begin{tikzpicture}[scale=0.6]
@@ -112,7 +112,7 @@
                     <caption>A</caption>
                 </figure>
                 <figure>
-                    <image>
+                    <image xml:id="graph-horizontal-asymptotes-2">
                     <latex-image>
                         \begin{tikzpicture}[scale=0.6]
                         \begin{axis}[
@@ -131,7 +131,7 @@
                     <caption>B</caption>
                 </figure>
                 <figure>
-                    <image>
+                    <image xml:id="graph-horizontal-asymptotes-3">
                     <latex-image>
                   \begin{tikzpicture}[scale=0.6]
                         \begin{axis}[
@@ -153,7 +153,7 @@
             </sidebyside>
             <sidebyside>
                 <figure>
-                    <image>
+                    <image xml:id="graph-horizontal-asymptotes-4">
                     <latex-image>
                 \begin{tikzpicture}[scale=0.6]
                         \begin{axis}[
@@ -173,7 +173,7 @@
                     <caption>D</caption>
                 </figure>
                 <figure>
-                    <image>
+                    <image xml:id="graph-horizontal-asymptotes-5">
                     <latex-image>
                        \begin{tikzpicture}[scale=0.6]
                         \begin{axis}[
@@ -193,7 +193,7 @@
                     <caption>E</caption>
                 </figure>
                 <figure>
-                    <image>
+                    <image xml:id="graph-horizontal-asymptotes-6">
                     <latex-image>
                      \begin{tikzpicture}[scale=0.6]
                         \begin{axis}[
@@ -339,7 +339,7 @@ the value of each limit.
 What is your best guess for the limit as <m> x</m> goes to <m>+ \infty </m> of the function graphed below?
             </p>
             <figure>
-                <image width="50%">
+                <image width="50%" xml:id="graph-limit-guess">
                           <latex-image>
                 \begin{tikzpicture}
 \begin{axis}[
@@ -396,7 +396,7 @@ What is your best guess for the limit as <m> x</m> goes to <m>+ \infty </m> of t
         <introduction>
             <p>   The graph below represents the function <m>f(x) =  \displaystyle\frac{2(x+3)(x+1)}{x^2-2x-3}</m>.   </p>
              <figure>
-                    <image width="50%">
+                    <image width="50%" xml:id="graph-rational-function">
                     <latex-image>
 \begin{tikzpicture}[scale=1]
 \begin{axis}[

--- a/source/01-LT/06.ptx
+++ b/source/01-LT/06.ptx
@@ -19,7 +19,7 @@
                 Consider the graph in <xref ref="vert-asymp" />.
             </p>
             <figure xml:id="vert-asymp">
-                <image width="50%">
+                <image width="50%" xml:id="graph-vertical-asymptote">
                           <latex-image xml:id="vert-asymp-tikz"><xi:include href="./tikz/vert-asymp.tex" parse="text"/></latex-image>
                     </image>
                     <caption> The graph of <m>1/x^2</m>.</caption>
@@ -228,7 +228,7 @@ Explain and demonstrate how to find the value of each limit.
         <introduction>
             <p>   The graph below represents the function <m>f(x) =  \displaystyle\frac{(x+2)(x+4)}{x^2+3x-4}</m>.   </p>
              <figure>
-                    <image width="50%">
+                    <image width="50%" xml:id="graph-rational-practice-2">
                     <latex-image xml:id="rational-pratice2-tikz"><xi:include href="./tikz/rational-practice2.tex" parse="text"/></latex-image>
                     </image>
                     <caption>The graph of <m> f(x)</m></caption>

--- a/source/02-DF/01.ptx
+++ b/source/02-DF/01.ptx
@@ -130,7 +130,7 @@
                 <p> In this activity you will study the slope of a graph at a point. The graph of the function <m>g(x)</m> is given below. For your convenience, below you will find a table of values for <m>g(x)</m>.
 </p>
                    <figure>
-                    <image width="50%">
+                    <image width="50%" xml:id="graph-parabola">
                     <latex-image>  
 \begin{tikzpicture}[scale=1]
 \begin{axis}[
@@ -275,7 +275,7 @@
               <introduction> 
                 <p> In this activity you will study the abolute value function <m>f(x)=|x|</m>. The absolute value function is a piecewise defined function which outputs <m>x</m> when <m>x</m> is positive (or zero) and outputs <m>-x</m> when <m>x</m> is negative. So the absolute value always outputs a number which is positive (or zero). Here is the graph of this function. </p>
                    <figure>
-                    <image width="50%">
+                    <image width="50%" xml:id="graph-absolute-value">
                     <latex-image>  
 \begin{tikzpicture}[scale=1]
 \begin{axis}[
@@ -332,7 +332,7 @@
         <introduction>
         <p>Consider the graph of function <m>h(x)</m>. </p>
        <figure xml:id = "nice-piecewise-graph">
-                    <image width="50%">
+                    <image width="50%" xml:id="graph-derivative-features">
                     <latex-image>  
         \begin{tikzpicture}[scale=1]
 \begin{axis}[
@@ -446,7 +446,7 @@ The rate of change of <m>f(x)</m> when <m>x=-1</m> is positive
         <introduction>
         <p>You are given the graph of the function <m>f(x)</m>.</p>
          <figure>
-                    <image width="50%">
+                    <image width="50%" xml:id="graph-tangent-line-estimate">
                     <latex-image>  
 \begin{tikzpicture}[scale=1]
 \begin{axis}[

--- a/source/02-DF/05.ptx
+++ b/source/02-DF/05.ptx
@@ -122,7 +122,7 @@
   <activity xml:id="chain-rule-practice-graphs">
    <introduction>  <p>Below you are given the graphs of two functions: <m>a(x)</m> and <m>b(x)</m>. Use the graphs to compute vaules of composite functions and of their derivatives, when possible (there are points where the derivative of these functions is not defined!). Notice that to compute the derivative at a point, you first want to find the derivative as a function of <m>x</m> and then plug in the input you want to study.  </p>
          <figure>
-                    <image>
+                    <image xml:id="graph-chain-rule-practice">
                     <latex-image>
 \begin{tikzpicture}
 \begin{axis}[

--- a/source/02-DF/08.ptx
+++ b/source/02-DF/08.ptx
@@ -80,7 +80,7 @@ the derivative of <m>g = f^{-1}</m>, the inverse function of <m>f</m>, is given 
     
 <activity xml:id="activity-df-inv-graph"> <introduction><p>In this problem you will apply the general formula for the derivative of the inverse function to find the values of some derivatives graphically.</p> 
     <figure>
-                    <image>
+                    <image xml:id="graph-df-inv">
                     <latex-image>  
     \begin{tikzpicture}[scale=1]
 \begin{axis}[
@@ -196,7 +196,7 @@ the derivative of <m>g = f^{-1}</m>, the inverse function of <m>f</m>, is given 
 </p></task>
     <task><p>From the graph of <m>y=\sin(x)</m> and your table above, graph the arcsine function  <m>y=\sin^{-1}(x)</m> </p>
      <figure>
-                    <image>
+                    <image xml:id="graph-tan">
                     <latex-image>  
 \begin{tikzpicture}
 \begin{axis}[
@@ -306,7 +306,7 @@ the derivative of <m>g = f^{-1}</m>, the inverse function of <m>f</m>, is given 
       <introduction><p>Let <m>y=f(v)</m> be the gas consumption (in ml/km) of a car at velocity <m>v</m> (in km/hr). We use the notation: ml for milliliters, km for kilometers, and hr for hours. Also consider the function <m>g(y)</m>, where <m>v=g(y)</m> is the function that gives the velocity <m>v</m> (in km/hr) when the gas consumption is <m>y</m> (in ml/km).
 You are given the graphs of <m>f(v), f'(v)</m> below. </p>
  <figure>
-                    <image>
+                    <image xml:id="graph-inverses-in-context2">
                     <latex-image>  
       \begin{tikzpicture}[scale=0.8]
 \begin{axis}[

--- a/source/03-AD/02.ptx
+++ b/source/03-AD/02.ptx
@@ -51,7 +51,7 @@ Notice that this is obtained by writing the tangent line to <m>f(x)</m> at <m>(a
     <task><p>Sketch the tangent line <m>L(x)</m> on the same plane as the graph of <m>\ln(x)</m>. What do you notice? 
 </p>
          <figure>
-                    <image width="50%">
+                    <image width="50%" xml:id="graph-tangent-line-plane-ln">
                     <latex-image>  
 \begin{minipage}{\textwidth}
 \begin{center}

--- a/source/03-AD/04.ptx
+++ b/source/03-AD/04.ptx
@@ -26,7 +26,7 @@
     </p>
 
  <figure xml:id="height-function">
-                    <image width="50%">
+                    <image width="50%" xml:id="graph-parabolic-height-function">
                     <latex-image>
 \begin{tikzpicture}[scale=1]
 \begin{axis}[

--- a/source/07-CO/05.ptx
+++ b/source/07-CO/05.ptx
@@ -68,7 +68,7 @@ into the equation to produce its <m>y</m> value.
             <p>Plot each point <m>(x,y)</m> in your chart in the <m>xy</m> plane.</p>
             <figure>
                 <caption>Plot of <m>y=2-x^2</m>.</caption>
-                <image width="100%">
+                <image width="100%" xml:id="graph-parabola-plot-points">
                     <description>Plot of <m>y=2-x^2</m>.</description>
                     <latex-image>
                         \begin{tikzpicture}
@@ -129,7 +129,7 @@ into the equations to produce its <m>x</m> and <m>y</m> values.
             <p>Plot each point <m>(x,y)</m> in your chart in the <m>xy</m> plane, labeling it with its <m>t</m> value.</p>
             <figure>
                 <caption>Plot of <m>x=t-2</m>, <m>y=-t^2+4t-2</m>.</caption>
-                <image width="100%">
+                <image width="100%" xml:id="graph-parabola-plot-points2">
                     <description>Plot of <m>y=2-x^2</m>.</description>
                     <latex-image>
                         \begin{tikzpicture}

--- a/source/07-CO/06.ptx
+++ b/source/07-CO/06.ptx
@@ -139,7 +139,7 @@ into the equation to produce its <m>y</m> value.
             <p>Plot each point <m>(x,y)</m> in your chart in the <m>xy</m> plane.</p>
             <figure>
                 <caption>Plot of <m>y=2-x^2</m>.</caption>
-                <image width="100%">
+                <image width="100%" xml:id="graph-parabola-plotpoints-3">
                     <description>Plot of <m>y=2-x^2</m>.</description>
                     <latex-image>
                         \begin{tikzpicture}
@@ -200,7 +200,7 @@ into the equations to produce its <m>x</m> and <m>y</m> values.
             <p>Plot each point <m>(x,y)</m> in your chart in the <m>xy</m> plane, labeling it with its <m>t</m> value.</p>
             <figure>
                 <caption>Plot of <m>x=t-2</m>, <m>y=-t^2+4t-2</m>.</caption>
-                <image width="100%">
+                <image width="100%" xml:id="graph-parbola-plot-points-4">
                     <description>Plot of <m>y=2-x^2</m>.</description>
                     <latex-image>
                         \begin{tikzpicture}


### PR DESCRIPTION
Addresses #78.  Audit results:

```
(base) drew@Drews-MBP calculus % grep -n '<image' source/*/*.ptx | grep -v xml:id | grep -v '<!--' | grep -v 'source=' 
(base) drew@Drews-MBP calculus % 
```

There are 30-40 `<image>`s that have a `@source` but no `@xml:id`; but I think it's okay to leave them.