### PR TITLE
Update 01.ptx

### DIFF
--- a/source/09-PS/01.ptx
+++ b/source/09-PS/01.ptx
@@ -486,7 +486,7 @@
             </introduction>
             <task>
                 <p>
-                    Find <m>p_3(x)</m>, the degree 4 polynomial approximation for <m>p(x)</m>.
+                    Find <m>p_3(x)</m>, the degree 3 polynomial approximation for <m>p(x)</m>.
                 </p>
             </task>
             <task>


### PR DESCRIPTION
[Definition 9.1.2](https://teambasedinquirylearning.github.io/calculus/2023/PS1.html#definition-44) says that p_N is the Nth degree approximation but [this Activity](https://teambasedinquirylearning.github.io/calculus/2023/PS1.html#task-957) had typo saying p_3 is the 4th degree approximation. Changed 4th degree to 3rd in question prompt.