### PR TITLE
Update Active Calc attribution

### DIFF
--- a/source/meta/frontmatter.ptx
+++ b/source/meta/frontmatter.ptx
@@ -97,7 +97,7 @@ This work includes materials used under license from the following works:
                       <p><url href="https://activecalculus.org/ACS.html"/></p>
                   </li>
                   <li>
-                      <p>CC BY-SA 2.0</p>
+                      <p>CC BY-SA 4.0</p>
                   </li>
               </ul>
           </li>


### PR DESCRIPTION
Not sure if it was updated at some point, but Active Calculus currently lists the 4.0 version of CC BY-SA as its license: https://activecalculus.org/single/colophon-1.html