### PR TITLE
Add print-latex target

### DIFF
--- a/project.ptx
+++ b/project.ptx
@@ -32,5 +32,6 @@
       <!-- built by checkit, not pretext -->
       <!-- everything except output-dir and deploy-dir is unused -->
     </target>
+    <target name="print-latex" format="latex"/>
   </targets>
 </project>


### PR DESCRIPTION
I told @AbbyANoble she could just generate the LaTeX to include a textbook section in an article, but the target was missing from the project.ptx. Once this is merged, users can run `pretext build print-latex` to generate the LaTeX file that creates the PDF version.